### PR TITLE
Explicit count modifiers

### DIFF
--- a/Syntaxes/Bro.JSON-tmLanguage
+++ b/Syntaxes/Bro.JSON-tmLanguage
@@ -22,7 +22,7 @@
 			"patterns": [
 				{
 					"name": "constant.character.escape.bro", 
-					"match": "\\\\(\\\\|[abefnprtv'\"?]|[0-3]\\d{,2}|[4-7]\\d?|x[a-fA-F0-9]{,2})"
+					"match": "\\\\(\\\\|[abefnprtv'\"?]|[0-3]\\d{0,2}|[4-7]\\d?|x[a-fA-F0-9]{0,2})"
 				},
 				{
 					"name": "constant.character.escape.bro",

--- a/Syntaxes/Bro.tmLanguage
+++ b/Syntaxes/Bro.tmLanguage
@@ -544,7 +544,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2})</string>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2})</string>
 					<key>name</key>
 					<string>constant.character.escape.bro</string>
 				</dict>


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by Sublime Text). This package is used to highlight Bro code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes and thus, the following code gets incorrectly highlighted.

``` bro
value = "\00";
```

This pull request fixes that by using an explicit count modifier in the regex.
