### PR TITLE
Fix issue with SublimeText3

### DIFF
--- a/BroIndent.py
+++ b/BroIndent.py
@@ -10,7 +10,7 @@ def insert_newline_and_indent(edit, view):
 	for i in range(total):
 		idx = view.sel()[i].begin()
 		line = view.substr(view.line(view.sel()[i]))
-		print line
+#		print line
 		indent = current_indent(line)
 		indents = "\t" * (indent == 0 and 0 or indent+1)
 		view.insert(edit, idx,


### PR DESCRIPTION
This commit simply comments out a print statement that I assume was used for debugging. It causes a plugin runtime error resulting in a non-functional enter key following a closing curly bracket.

For example, using this syntax as a test place the cursor right after the closing curly bracket and the enter key will appear to be unresponsive. 

export
    {
    const test = 20.0 &redef;
    }
